### PR TITLE
Use useCallback in response.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ import Result from './result';
 
 const FetchComponent = () => {
   const isMounted = useIsMounted();
-  const [data, setdata] = useState(null);
+  const [data, setData] = useState(null);
 
   useEffect(() => {
     const fetchData = async () => {

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ const FetchComponent = () => {
     };
 
     fetchData();
-  }, []);
+  }, [isMounted]);
 
   return data ? <Result data={data} /> : <Loading />;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-is-mounted-hook",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/use-is-mounted.tsx
+++ b/src/use-is-mounted.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect } from 'react';
+import { useRef, useEffect, useCallback } from 'react';
 
 export default function useIsMounted(): () => boolean {
   const ref = useRef(false);
@@ -10,5 +10,5 @@ export default function useIsMounted(): () => boolean {
     };
   }, []);
 
-  return () => ref.current;
+  return useCallback(() => ref.current, [ref]);
 }


### PR DESCRIPTION
Wraps the function that is returned in a `useCallback` so that `isMounted` can be used in dependency arrays safely. Updates the README to show that this is possible.