### PR TITLE
Fix react version constraints

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-is-mounted-hook",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "React hook to check if the component is still mounted",
   "keywords": [
     "react",
@@ -25,8 +25,8 @@
     "prepare": "npm run build"
   },
   "peerDependencies": {
-    "react": "^16.8.6 || >17",
-    "react-dom": "^16.8.6 || >17"
+    "react": "^16.8.6 || ^17",
+    "react-dom": "^16.8.6 || ^17"
   },
   "devDependencies": {
     "@types/jest": "^26.0.22",


### PR DESCRIPTION
The package triggers following error when installing with React 17:
```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR!
npm ERR! While resolving: demo-app@0.1.0
npm ERR! Found: react@17.0.2
npm ERR! node_modules/react
npm ERR!   react@"^17.0.2" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer react@"^16.8.6 || >17" from react-is-mounted-hook@1.1.1
npm ERR! node_modules/react-is-mounted-hook
npm ERR!   react-is-mounted-hook@"*" from the root project
```

This is because `>17` does not include `17.x.x`: https://jubianchi.github.io/semver-check/#/%3E17/17.0.2